### PR TITLE
MaxValue Rule should only fail, when $value is higher than the given …

### DIFF
--- a/src/Forms/Rules/MaxValueRule.php
+++ b/src/Forms/Rules/MaxValueRule.php
@@ -27,7 +27,7 @@ readonly class MaxValueRule implements ValidationRule
                 $locale
             );
 
-            if ($minorValue >= $this->max) {
+            if ($minorValue > $this->max) {
                 $fail(
                     strtr(
                         'The {attribute} must be less than or equal to {value}.',


### PR DESCRIPTION
…maximal value